### PR TITLE
Install Home Manager during macOS bootstrap

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -7,3 +7,5 @@ Home Manager のエントリポイント:
 ```sh
 home-manager switch -f ./macos/home.nix
 ```
+
+bootstrap は `home-manager` が未インストールなら、Home Manager の channel を追加して install してから適用する。

--- a/macos/bootstrap/macos.sh
+++ b/macos/bootstrap/macos.sh
@@ -2,4 +2,18 @@
 set -euxo pipefail
 
 repo_root=$(cd "$(dirname "$0")/.." && pwd)
+
+if ! command -v nix >/dev/null 2>&1; then
+  echo "nix command not found" >&2
+  exit 1
+fi
+
+if ! command -v home-manager >/dev/null 2>&1; then
+  nix-channel --add \
+    https://github.com/nix-community/home-manager/archive/release-25.05.tar.gz \
+    home-manager
+  nix-channel --update
+  nix-shell '<home-manager>' -A install
+fi
+
 home-manager switch -f "$repo_root/home.nix"


### PR DESCRIPTION
## Summary
- install Home Manager during macOS bootstrap when the command is missing
- document that bootstrap sets up Home Manager before applying the config

## Testing
- bash -n macos/bootstrap/macos.sh