### PR TITLE
Bootstrap Nix and Home Manager on macOS

### DIFF
--- a/macos/README.md
+++ b/macos/README.md
@@ -8,4 +8,4 @@ Home Manager のエントリポイント:
 home-manager switch -f ./macos/home.nix
 ```
 
-bootstrap は `home-manager` が未インストールなら、Home Manager の channel を追加して install してから適用する。
+bootstrap は `nix` が未インストールなら先に Nix を入れ、`home-manager` が未インストールなら Home Manager を install してから適用する。

--- a/macos/bootstrap/macos.sh
+++ b/macos/bootstrap/macos.sh
@@ -4,8 +4,8 @@ set -euxo pipefail
 repo_root=$(cd "$(dirname "$0")/.." && pwd)
 
 if ! command -v nix >/dev/null 2>&1; then
-  echo "nix command not found" >&2
-  exit 1
+  sh <(curl -L https://nixos.org/nix/install)
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
 fi
 
 if ! command -v home-manager >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- install Nix during macOS bootstrap when the nix command is missing
- install Home Manager during bootstrap when the command is missing
- keep the macOS bootstrap script executable

## Testing
- bash -n macos/bootstrap/macos.sh