### PR TITLE
fix(macos): run bootstrap script with bash

### DIFF
--- a/macos/bootstrap/macos.sh
+++ b/macos/bootstrap/macos.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -euxo pipefail
 
 repo_root=$(cd "$(dirname "$0")/.." && pwd)


### PR DESCRIPTION
## Summary
- change the macOS bootstrap script shebang to bash
- match the existing Bash-specific syntax used in the script
- avoid the syntax error triggered by process substitution under /bin/sh
