### PR TITLE
fix(macos): back up files before home-manager switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ macOS の bootstrap:
 macOS で Home Manager を直接使う場合:
 
 ```sh
-home-manager switch -I nixpkgs=channel:nixpkgs -f ./macos/home.nix
+home-manager switch -b backup -I nixpkgs=channel:nixpkgs -f ./macos/home.nix
 ```
 
 Ghostty 設定は Home Manager から配布する。

--- a/macos/README.md
+++ b/macos/README.md
@@ -5,7 +5,7 @@ macOS 向けの設定はこのディレクトリ以下に追加していく。
 Home Manager のエントリポイント:
 
 ```sh
-home-manager switch -I nixpkgs=channel:nixpkgs -f ./macos/home.nix
+home-manager switch -b backup -I nixpkgs=channel:nixpkgs -f ./macos/home.nix
 ```
 
 bootstrap は `nix` が未インストールなら先に Nix を入れ、`nixpkgs` と `home-manager` のリリースを揃えてから適用する。

--- a/macos/bootstrap/macos.sh
+++ b/macos/bootstrap/macos.sh
@@ -20,4 +20,4 @@ if ! command -v home-manager >/dev/null 2>&1; then
   nix-shell '<home-manager>' -A install
 fi
 
-home-manager switch -I nixpkgs=channel:nixpkgs -f "$repo_root/home.nix"
+home-manager switch -b backup -I nixpkgs=channel:nixpkgs -f "$repo_root/home.nix"


### PR DESCRIPTION
## Summary
- run standalone Home Manager with `-b backup` in the macOS bootstrap script
- update the direct invocation examples in the README files
- avoid clobbering existing files such as `~/.config/ghostty/config`
