### PR TITLE
fix: add Ghostty helper keybinds for Raycast layout

### DIFF
--- a/nix/ghostty/config
+++ b/nix/ghostty/config
@@ -46,3 +46,8 @@ keybind = chain=new_split:right
 keybind = chain=goto_split:right
 keybind = chain=text:~/.ghq/github.com/uta8a/virtual-monorepo/start-ghostty.sh\r
 keybind = chain=equalize_splits
+
+# Raycast helper for deterministic 3-split setup.
+keybind = cmd+alt+ctrl+shift+1=new_split:right
+keybind = cmd+alt+ctrl+shift+2=goto_split:right
+keybind = cmd+alt+ctrl+shift+3=equalize_splits


### PR DESCRIPTION
## Summary
- add dedicated Ghostty helper keybinds for split creation and navigation
- support the Raycast automation that opens the 3-split Codex layout deterministically

## Testing
- bash -n ../../start-ghostty.sh